### PR TITLE
RFC for trait bounds on generic parameters of const fns

### DIFF
--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -8,8 +8,9 @@
 
 Allow `const impl`s for trait impls where all method impls are checked as const fn.
 
-Make it legal to declare trait bounds on generic parameters of `const fn` and allow
-the body of the const fn to call methods on these generic parameters.
+Make it legal to declare trait bounds on generic parameters of const functions and allow
+the body of the const fn to call methods on the generic parameters that have a `const` modifier
+on their bound.
 
 # Motivation
 [motivation]: #motivation
@@ -21,26 +22,26 @@ generic parameter type), because they are fully unconstrained.
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-You can call call methods of generic parameters of `const fn`, because they are implicitly assumed to be
-`const fn`. For example, even though the `Add` trait declaration does not contain any mention of `const`,
+You can call call methods of generic parameters of a const function, because they are implicitly assumed to be
+`const fn`. For example, the `Add` trait declaration has an additional `const` before the trait name, so
 you can use it as a trait bound on your generic parameters:
 
 ```rust
-const fn triple_add<T: Add>(a: T, b: T, c: T) -> T {
+const fn triple_add<T: const Add>(a: T, b: T, c: T) -> T {
     a + b + c
 }
 ```
 
 The obligation is passed to the caller of your `triple_add` function to supply a type whose `Add` impl is fully
 `const`. Since `Add` only has `add` as a method, in this case one only needs to ensure that the `add` method is
-`const fn`. Instead of adding a `const` modifier to all methods of a trait impl, the modifier is added to the entire
+`const`. Instead of adding a `const` modifier to all methods of a trait impl, the modifier is added to the entire
 `impl` block:
 
 ```rust
 struct MyInt(i8);
 const impl Add for MyInt {
     fn add(self, other: Self) -> Self {
-        MyInt(self.0, other.0)
+        MyInt(self.0 + other.0)
     }
 }
 ```
@@ -65,23 +66,17 @@ const impl Hash for MyInt {
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
-This is the technical portion of the RFC. Explain the design in sufficient detail that:
-
-- Its interaction with other features is clear.
-- It is reasonably clear how the feature would be implemented.
-- Corner cases are dissected by example.
-
-The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+The implementation of this RFC is (in contrast to some of its alternatives) mostly
+changes around the syntax of the language (adding `const` modifiers in a few places)
+and ensuring that lowering to HIR and MIR keeps track of that.
+The miri engine already fully supports calling methods on generic
+bounds, there's just no way of declaring them.
 
 # Drawbacks
 [drawbacks]: #drawbacks
 
-One cannot add trait bounds to `const fn` without them automatically
-requiring `const impl`s for all monomorphizations. Even if one does not
-call any method on the generic parameter, the methods are still required to be constant.
-
 It is not a fully general design that supports every possible use case,
-but only covers the most common cases. See also the alternatives.
+but it covers the most common cases. See also the alternatives.
 
 # Rationale and alternatives
 [rationale-and-alternatives]: #rationale-and-alternatives
@@ -97,13 +92,17 @@ and this RFC is forward compatible to have its background impl be an effect syst
 One could annotate methods instead of impls, allowing just marking some method impls
 as const fn. This would require some sort of "const bounds" in generic functions that
 can be applied to specific methods. E.g. `where <T as Add>::add: const` or something of
-the sort.
+the sort. This design is more complex than the current one and we'd probably want the
+current one as sugar anyway
 
-## Explicit `const` bounds
+## No explicit `const` bounds
 
-One could require `T: const Trait` bounds to differentiate between bounds on which methods
-can be called and bounds on which no methods can be called. This can backwards compatibly be
-added as an opt-out via `T: ?const Trait` if the desire for such differences is strong.
+One could require no `const` on the bounds (e.g. `T: Trait`) and assume constness for all
+bounds. An opt-out via `T: ?const Trait` would then allow declaring bounds that cannot be
+used for calling methods. This design causes discrepancies with `const fn` pointers as
+arguments (where the constness would be needed, as normal function pointers already exist
+as the type of constants). Also it is not forward compatible to allowing `const` trait bounds
+on non-const functions
 
 ## Infer all the things
 
@@ -117,7 +116,40 @@ This is strictly the most powerful and generic variant, but is an enormous backw
 hazard as changing a const fn's body to suddenly call a method that it did not before can break
 users of the function.
 
+# Future work
+
+This design is explicitly forward compatible to all future extensions the author could think
+about. Notable mentions (see also the alternatives section):
+
+* an effect system with a "notconst" effect
+* const trait bounds on non-const functions allowing the use of the generic parameter in
+  constant expressions in the body of the function or maybe even for array lenghts in the
+  signature of the function
+* fine grained bounds for single methods and their bounds
+
+It might also be desirable to make the automatic `Fn*` impls on function types and pointers `const`.
+This change should probably go in hand with allowing `const fn` pointers on const functions
+that support being called (in contrast to regular function pointers).
+
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-None
+Should `const impl` blocks additionally generate impls that are not const if any generic
+parameters are not const?
+
+E.g.
+
+```rust
+const impl<T: Add> Add for Foo<T> {
+    fn add(self, other: Self) -> Self {
+        Foo(self.0 + other.0)
+    }
+}
+```
+
+would allow calling `Foo(String::new()) + Foo(String::new())` even though that is (at the time
+of writing this RFC) most definitely not const.
+
+This would go in hand with the current scheme for const functions, which may also be called
+at runtime with runtime arguments, but are checked for soundness as if they were called in
+a const context.

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -1,0 +1,123 @@
+- Feature Name: const_generic_const_fn_bounds
+- Start Date: 2018-10-05
+- RFC PR: (leave this empty)
+- Rust Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+Allow `const impl`s for trait impls where all method impls are checked as const fn.
+
+Make it legal to declare trait bounds on generic parameters of `const fn` and allow
+the body of the const fn to call methods on these generic parameters.
+
+# Motivation
+[motivation]: #motivation
+
+Currently one can declare const fns with generic parameters, but one cannot add trait bounds to these
+generic parameters. Thus one is not able to call methods on the generic parameters (or on objects of the
+generic parameter type), because they are fully unconstrained.
+
+# Guide-level explanation
+[guide-level-explanation]: #guide-level-explanation
+
+You can call call methods of generic parameters of `const fn`, because they are implicitly assumed to be
+`const fn`. For example, even though the `Add` trait declaration does not contain any mention of `const`,
+you can use it as a trait bound on your generic parameters:
+
+```rust
+const fn triple_add<T: Add>(a: T, b: T, c: T) -> T {
+    a + b + c
+}
+```
+
+The obligation is passed to the caller of your `triple_add` function to supply a type whose `Add` impl is fully
+`const`. Since `Add` only has `add` as a method, in this case one only needs to ensure that the `add` method is
+`const fn`. Instead of adding a `const` modifier to all methods of a trait impl, the modifier is added to the entire
+`impl` block:
+
+```rust
+struct MyInt(i8);
+const impl Add for MyInt {
+    fn add(self, other: Self) -> Self {
+        MyInt(self.0, other.0)
+    }
+}
+```
+
+The const requirement is propagated to all bounds of the impl or its methods,
+so in the following `H` is required to have a const impl of `Hasher`, so that
+methods on `state` are callable.
+
+```rust
+const impl Hash for MyInt {
+    fn hash<H>(
+        &self,
+        state: &mut H,
+    )
+        where H: Hasher
+    {
+        state.write(&[self.0 as u8]);
+    }
+}
+```
+
+# Reference-level explanation
+[reference-level-explanation]: #reference-level-explanation
+
+This is the technical portion of the RFC. Explain the design in sufficient detail that:
+
+- Its interaction with other features is clear.
+- It is reasonably clear how the feature would be implemented.
+- Corner cases are dissected by example.
+
+The section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
+
+# Drawbacks
+[drawbacks]: #drawbacks
+
+One cannot add trait bounds to `const fn` without them automatically
+requiring `const impl`s for all monomorphizations. Even if one does not
+call any method on the generic parameter, the methods are still required to be constant.
+
+It is not a fully general design that supports every possible use case,
+but only covers the most common cases. See also the alternatives.
+
+# Rationale and alternatives
+[rationale-and-alternatives]: #rationale-and-alternatives
+
+## Effect system
+
+A fully powered effect system can allow us to do fine grained constness propagation
+(or no propagation where undesirable). This is way out of scope in the near future
+and this RFC is forward compatible to have its background impl be an effect system.
+
+## Fine grained `const` annotations
+
+One could annotate methods instead of impls, allowing just marking some method impls
+as const fn. This would require some sort of "const bounds" in generic functions that
+can be applied to specific methods. E.g. `where <T as Add>::add: const` or something of
+the sort.
+
+## Explicit `const` bounds
+
+One could require `T: const Trait` bounds to differentiate between bounds on which methods
+can be called and bounds on which no methods can be called. This can backwards compatibly be
+added as an opt-out via `T: ?const Trait` if the desire for such differences is strong.
+
+## Infer all the things
+
+We can just throw all this complexity out the door and allow calling any method on generic
+parameters without an extra annotation `iff` that method satisfies `const fn`. So we'd still
+annotate methods in trait impls, but we would not block calling a function on whether the
+generic parameters fulfill some sort of constness rules. Instead we'd catch this during
+const evaluation.
+
+This is strictly the most powerful and generic variant, but is an enormous backwards compatibility
+hazard as changing a const fn's body to suddenly call a method that it did not before can break
+users of the function.
+
+# Unresolved questions
+[unresolved-questions]: #unresolved-questions
+
+None

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -22,7 +22,7 @@ generic parameter type), because they are fully unconstrained.
 # Guide-level explanation
 [guide-level-explanation]: #guide-level-explanation
 
-You can call call methods of generic parameters of a const function, because they are implicitly assumed to be
+You can call methods of generic parameters of a const function, because they are implicitly assumed to be
 `const fn`. For example, the `Add` trait declaration has an additional `const` before the trait name, so
 you can use it as a trait bound on your generic parameters:
 

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -70,7 +70,7 @@ for the associated type:
 trait Foo {
     type Bar: Add;
 }
-impl Foo for A {
+impl const Foo for A {
     type Bar = B; // B must have an `impl const Add for B`
 }
 ```

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -117,7 +117,7 @@ struct Bar(Foo);
 impl const Drop for Foo { fn drop(&mut self) {} } // not allowed
 ```
 
-## Runtime uses don't have `const` restrictions?
+## Runtime uses don't have `const` restrictions
 
 `impl const` blocks additionally generate impls that are not const if any generic
 parameters are not const.

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -139,7 +139,7 @@ effect syntax nor effect semantics are proposed by this RFC, the following is ju
 purposes):
 
 ```rust
-impl<constness c, T: const(c) Add> const(c) Add for Foo<T> {
+impl<c: constness, T: const(c) Add> const(c) Add for Foo<T> {
     const(c) fn add(self, other: Self) -> Self {
         Foo(self.0 + other.0)
     }
@@ -166,7 +166,7 @@ const fn add<T: Add>(a: T, b: T) -> T {
 Using the same effect syntax from above:
 
 ```rust
-<constness c> const(c) fn add<T: const(c) Add>(a: T, b: T) -> T {
+<c: constness> const(c) fn add<T: const(c) Add>(a: T, b: T) -> T {
     a + b
 }
 ```

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -153,3 +153,8 @@ of writing this RFC) most definitely not const.
 This would go in hand with the current scheme for const functions, which may also be called
 at runtime with runtime arguments, but are checked for soundness as if they were called in
 a const context.
+
+## Drop
+
+Should we also allow `(SomeDropType, 42).1` as an expression if `SomeDropType`'s `Drop` impl
+was declared with `const impl Drop`?

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -83,6 +83,16 @@ Then you are allowed to actually let a value of `SomeDropType` get dropped withi
 evaluation. This means `(SomeDropType(&Cell::new(42)), 42).1` is now allowed, because we can prove
 that everything from the creation of the value to the destruction is const evaluable.
 
+Note that all fields of types with a `const Drop` impl must have `const Drop` impls, too, as the
+compiler will automatically generate `Drop::drop` calls to the fields:
+
+```rust
+struct Foo;
+impl Drop for Foo { fn drop(&mut self) {} }
+struct Bar(Foo);
+impl const Drop for Foo { fn drop(&mut self) {} } // not allowed
+```
+
 ## Runtime uses don't have `const` restrictions?
 
 `impl const` blocks additionally generate impls that are not const if any generic

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -87,7 +87,9 @@ The implementation of this RFC is (in contrast to some of its alternatives) most
 changes around the syntax of the language (adding `const` modifiers in a few places)
 and ensuring that lowering to HIR and MIR keeps track of that.
 The miri engine already fully supports calling methods on generic
-bounds, there's just no way of declaring them.
+bounds, there's just no way of declaring them. Checking methods for constness is already implemented
+for inherent methods. The implementation will have to extend those checks to also run on methods
+of `const impl` items.
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -211,6 +211,8 @@ and `const` modifiers on `impl` blocks.
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
+## Runtime uses don't have `const` restrictions?
+
 Should `impl const` blocks additionally generate impls that are not const if any generic
 parameters are not const?
 
@@ -224,7 +226,7 @@ impl<T: Add> const Add for Foo<T> {
 }
 ```
 
-would allow calling `Foo(String::new()) + Foo(String::new())` even though that is (at the time
+would allow calling `Foo(String::from("foo")) + Foo(String::from("bar"))` even though that is (at the time
 of writing this RFC) most definitely not const, because `String` only has an `impl Add for String`
 and not an `impl const Add for String`.
 

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -129,7 +129,7 @@ situations like the one described above.
 ## `?const` opt out
 
 There is often desire to add bounds to a `const` function's generic arguments, without wanting to
-call any of the methods on those generic bounds. Prominent examples are `new` methods:
+call any of the methods on those generic bounds. Prominent examples are `new` functions:
 
 ```rust
 struct Foo<T: Trait>(T);
@@ -138,7 +138,8 @@ const fn new<T: Trait>(t: T) -> Foo<T> {
 }
 ```
 
-Unfortunately, with the given syntax in this RFC, one can now only call the `new` method if `T` has
+Unfortunately, with the given syntax in this RFC, one can now only call the `new` function in a const
+context if `T` has
 an `impl const Trait for T { ... }`. Thus an opt-out similar to `?Sized` can be used:
 
 ```rust

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -150,6 +150,24 @@ impl would suddenly stop being `const`, without any visible change to the API. T
 be allowed for the same reason as why we're not inferring `const` on functions: changes to private
 things should not affect the constness of public things, because that is not compatible with semver.
 
+One possible solution is to require an explicit `const` in the derive:
+
+```rust
+#[derive(const Clone)]
+pub struct Foo(Bar);
+
+struct Bar;
+
+const impl Clone for Bar {
+    fn clone(&self) -> Self { Bar }
+}
+```
+
+which would generate a `const impl Clone for Foo` block which would fail to compile if any of `Foo`'s
+fields (so just `Bar` in this example) are not implementing `Clone` via `const impl`. The obligation is
+now on the crate author to keep the public API semver compatible, but they can't accidentally fail to
+uphold that obligation by changing private things.
+
 ## RPIT (Return position impl trait)
 
 ```rust

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -185,12 +185,14 @@ in an `impl`. This has several uses, most notably
 * adding new methods is not a breaking change if they also have a default body
 
 In order to keep both advantages in the presence of `impl const`s, we need a way to declare the
-method default body as being `const`. The author of this RFC considers prepending the default body's
-method signature with `const` to be the most intuitive syntax.
+method default body as being `const`. The exact syntax for doing so is left as an open question to
+be decided during the implementation and following final comment period. For now one can add the
+`#[default_method_body_is_const]` attribute to the method.
 
 ```rust
 trait Foo {
-    const fn bar() {}
+    #[default_method_body_is_const]
+    fn bar() {}
 }
 ```
 
@@ -493,4 +495,5 @@ the function, would allow the above function to actually exist.
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions
 
-Everything has been addressed in the reviews
+The syntax for specifying that a trait method's default body is `const` is left unspecified and uses
+the `#[default_method_body_is_const]` attribute as the placeholder syntax.

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -81,14 +81,24 @@ for it.
 These rules for associated types exist to make this RFC forward compatible with adding const default bodies
 for trait methods. These are further discussed in the "future work" section.
 
-## Generic `impl` blocks
+## Generic bounds
 
-Similar to generic parameters on `const` functions, one can have generic parameters on `impl` blocks.
-These follow the same rules as bounds on `const` functions:
+The above section skimmed over a few topics for brevity. First of all, `impl const` items can also
+have generic parameters and thus bounds on these parameters, and these bounds follow the same rules
+as bounds on generic parameters on `const` functions: all bounds can only be substituted with types
+that have `impl const` items for all the bounds. Thus the `T` in the following `impl` requires that
+when `MyType<T>` is used in a const context, `T` needs to have an `impl const Add for Foo`.
 
-* all bounds are required to have `impl const` for substituted types if the impl is used in a const context
-    * except in the presence of `?const` (see below)
-* if the impl is used at runtime, there are no restrictions what kind of bounds are required
+```rust
+impl<T: Add> const Add for MyType<T> {
+    /* some code here */
+}
+const FOO: MyType<u32> = ...;
+const BAR: MyType<u32> = FOO + FOO; // only legal because `u32: const Add`
+```
+
+Furthermore, if `MyType` is used outside a const context, there are no constness requirements on the
+bounds for types substituted for `T`.
 
 ## Drop
 

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -328,6 +328,22 @@ const fn foo<T: ?const Foo>() -> i32 {
 
 even though the `?const` modifier explicitly opts out of constness.
 
+### `const` traits
+
+A further extension could be `const trait` declarations, which desugar to all methods being `const`:
+
+```rust
+const trait V {
+    fn foo(C) -> D;
+    fn bar(E) -> F;
+}
+// ...desugars to...
+trait V {
+    const fn foo(C) -> D;
+    const fn bar(E) -> F;
+}
+```
+
 ## `?const` modifiers in trait methods
 
 This RFC does not touch `trait` methods at all, all traits are defined as they would be defined

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -63,6 +63,23 @@ const impl Hash for MyInt {
 }
 ```
 
+## Drop
+
+A notable use case of `const impl` is defining `Drop` impls. If you write
+
+```rust
+struct SomeDropType<'a>(&'a Cell<u32>);
+const impl Drop for SomeDropType {
+    fn drop(&mut self) {
+        self.0.set(self.0.get() - 1);
+    }
+}
+```
+
+Then you are allowed to actually let a value of `SomeDropType` get dropped within a constant
+evaluation. This means `(SomeDropType(&Cell::new(42)), 42).1` is now allowed, because we can prove
+that everything from the creation of the value to the destruction is const evaluable.
+
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
@@ -212,11 +229,6 @@ and not a `const impl Add for String`.
 This would go in hand with the current scheme for const functions, which may also be called
 at runtime with runtime arguments, but are checked for soundness as if they were called in
 a const context.
-
-## Drop
-
-Should we also allow `(SomeDropType, 42).1` as an expression if `SomeDropType`'s `Drop` impl
-was declared with `const impl Drop`?
 
 ## Require `const` bounds on everything inside a `const impl` block?
 

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -176,6 +176,27 @@ const fn new<T: ?const Trait>(t: T) -> Foo<T> {
 }
 ```
 
+## `const` default method bodies
+
+Trait methods can have default bodies for methods that are used if the method is not mentioned
+in an `impl`. This has several uses, most notably
+
+* reducing code repetition between impls that are all the same
+* adding new methods is not a breaking change if they also have a default body
+
+In order to keep both advantages in the presence of `impl const`s, we need a way to declare the
+method default body as being `const`. The author of this RFC considers prepending the default body's
+method signature with `const` to be the most intuitive syntax.
+
+```rust
+trait Foo {
+    const fn bar() {}
+}
+```
+
+While this conflicts with future work ideas like `const` trait methods or `const trait` declarations,
+these features are unnecessary for full expressiveness as discussed in their respective sections.
+
 # Reference-level explanation
 [reference-level-explanation]: #reference-level-explanation
 
@@ -468,27 +489,6 @@ fn foo<T: const Bar>() -> i32 {
 
 Which, once `const` items and array lengths inside of functions can make use of the generics of
 the function, would allow the above function to actually exist.
-
-## `const` default method bodies
-
-Trait methods can have default bodies for methods that are used if the method is not mentioned
-in an `impl`. This has several uses, most notably
-
-* reducing code repetition between impls that are all the same
-* adding new methods is not a breaking change if they also have a default body
-
-In order to keep both advantages in the presence of `impl const`s, we need a way to declare the
-method default body as being `const`. The author of this RFC considers prepending the default body's
-method signature with `const` to be the most intuitive syntax.
-
-```rust
-trait Foo {
-    const fn bar() {}
-}
-```
-
-While this conflicts with other future work ideas like `const` trait methods or `const trait` declarations,
-these features are unnecessary for full expressiveness as discussed in their respective sections.
 
 # Unresolved questions
 [unresolved-questions]: #unresolved-questions

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -184,6 +184,7 @@ functions. The discussion and evolution of the type theoretical scheme can be fo
 [here](https://github.com/rust-rfcs/const-eval/pull/8#issuecomment-452396020) and is only 12 posts
 and a linked three page document long. It is left as an exercise to the reader to read the
 discussion themselves.
+A summary of the result of the discussion can be found at the bottom of [this blog post](https://varkor.github.io/blog/2019/01/11/const-types-traits-and-implementations-in-Rust.html)
 
 # Drawbacks
 [drawbacks]: #drawbacks

--- a/const-generic-const-fn-bounds.md
+++ b/const-generic-const-fn-bounds.md
@@ -144,6 +144,18 @@ of `impl const` items.
 7. Remove the call in https://github.com/rust-lang/rust/blob/f8caa321c7c7214a6c5415e4b3694e65b4ff73a7/src/librustc_passes/ast_validation.rs#L306
 8. Adjust the reference and the book to reflect these changes.
 
+## Const type theory
+
+This RFC was written after weighing practical issues against each other and finding the sweet spot
+that supports most use cases, is sound and fairly intuitive to use. A different approach from a
+type theoretical perspective started out with a much purer scheme, but, when exposed to the
+constraints required, evolved to essentially the same scheme as this RFC. We thus feel confident
+that this RFC is the minimal viable scheme for having bounds on generic parameters of const
+functions. The discussion and evolution of the type theoretical scheme can be found
+[here](https://github.com/rust-rfcs/const-eval/pull/8#issuecomment-452396020) and is only 12 posts
+and a linked three page document long. It is left as an exercise to the reader to read the
+discussion themselves.
+
 # Drawbacks
 [drawbacks]: #drawbacks
 


### PR DESCRIPTION
[Rendered](https://github.com/rust-rfcs/const-eval/blob/generic_const_fn_bounds/const-generic-const-fn-bounds.md)

cc @Centril @RalfJung @eddyb

Once we have gone through the process here, I'll post the final result on the regular RFC repo

Previous discussion: https://github.com/rust-rfcs/const-eval/issues/1

Glossary:

* [RPIT](https://github.com/rust-lang/rust/issues/34511) (return position impl trait)
* [const context](https://rust-lang-nursery.github.io/rustc-guide/const-eval.html)