### PR TITLE
Define promotion contexts and promotability

### DIFF
--- a/promotion.md
+++ b/promotion.md
@@ -28,10 +28,11 @@ first context where promotion was done.
 
 ### Non-`Copy` array initialization
 
-Another promotion context was introduced in [RFC
-2203](https://github.com/rust-rfcs/const-eval/blob/master/const.md). In this
-case, we try to promote the initializer in expressions like `[Vec::new(); 32]`,
-which allows non-`Copy` types to be used as array initializers.
+Another promotion context was introduced in [RFC 2203][]. In this case, we try
+to promote the initializer in expressions like `[Vec::new(); 32]`, which allows
+non-`Copy` types to be used as array initializers.
+
+[RFC 2203]: https://github.com/rust-lang/rfcs/blob/master/text/2203-const-repeat-expr.md
 
 ### `#[rustc_args_required_const(...)]`
 

--- a/promotion.md
+++ b/promotion.md
@@ -72,16 +72,38 @@ implicit context are a superset of the ones in an explicit context.
 
 [warn-rfc]: https://github.com/rust-lang/rfcs/blob/master/text/1229-compile-time-asserts.md
 
-### Promotion contexts in `const` and `static`
+### Promotion contexts inside `const` and `static`
+
+Lifetime extension is also responsible for making code like this work:
+
+```rust
+const FOO: &'static i32 = {
+    let x = &13;
+    x
+};
+```
 
 We defined above that promotion guarantees that code in a non-const context
-will be executed at compile-time. However, lifetime extension and non-`Copy`
-array initialization are useful features *inside* `const`s and `static`s as
-well. Strictly speaking, the transformation used to enable these features
-inside a const-context is not promotion; no `promoted`s are created in the MIR.
-However the same rules for promotability are used with one modification:
-Because the user has already requested that this code run at compile time, all
-contexts are treated as explicit.
+will be executed at compile-time. The above example illustrates that lifetime
+extension and non-`Copy` array initialization are useful features *inside*
+`const`s and `static`s as well. Strictly speaking, the transformation used to
+enable these features inside a const-context is not promotion; no `promoted`s
+are created in the MIR.  However the same rules for promotability are used with
+one modification: Because the user has already requested that this code run at
+compile time, all contexts are treated as explicit.
+
+Notice that some code involving `&` *looks* like it relies on lifetime
+extension but actually does not:
+
+```rust
+const EMPTY_BYTES: &Vec<u8> = &Vec::new(); // Ok without lifetime extension
+```
+
+As we have seen above, `Vec::new()` does not get promoted. And yet this
+compiles. Why that? The reason is that the reference obtains the lifetime of
+the "enclosing scope", similar to how `let x = &mut x;` creates a reference
+whose lifetime lasts for the enclosing scope. This is decided during MIR
+building already, and does not involve lifetime extension.
 
 ## Promotability
 
@@ -236,52 +258,6 @@ or `const` item and refer to that.
 
 *Dynamic check.* The Miri engine could dynamically check this by ensuring that
 the result of computing a promoted is a value that does not need dropping.
-
-## `&` in `const` and `static`
-
-Promotion is also responsible for making code like this work:
-
-```rust
-const FOO: &'static i32 = {
-    let x = &13;
-    x
-};
-```
-
-However, since this is in explicit const context, we are less strict about
-promotion in this situation: all function calls are promoted, not just
-`#[rustc_promotable]` functions:
-
-```rust
-const fn bar() -> i32 { 42 }
-
-const FOO: &'static i32 = {
-    let x = &bar(); // this gets promoted
-    x
-};
-```
-
-However, we still do not promote *everything*; e.g., drop-checking still applies:
-
-```rust
-const DROP: &'static Vec<u8> = {
-    let x = &Vec::new(); //~ ERROR: temporary value dropped while borrowed
-    x
-};
-```
-
-Notice that some code involving `&` *looks* like it relies on promotion but
-actually does not:
-
-```rust
-const EMPTY_BYTES: &Vec<u8> = &Vec::new(); // Ok without promotion
-```
-
-As we have seen above, `Vec::new()` does not get promoted. And yet this
-compiles. Why that? The reason is that the reference obtains the lifetime of
-the "enclosing scope", similar to how `let x = &mut x;` creates a reference
-whose lifetime lasts for the enclosing scope. This is decided during MIR
-building already, and does not involve promotion.
 
 ## Open questions
 

--- a/promotion.md
+++ b/promotion.md
@@ -115,16 +115,22 @@ resources for little benefit.
 
 ### Access to a `const` or `static`
 
-Accesses to `const`s are always promotable, regardless of the body of the
-`const`. For instance, while the previous example was not legal, the
-following would be:
+When accessing a `const` in a promotable context, the restrictions on single
+assignment and named locals do not apply to the body of the `const`. All other
+restrictions, notably that the result of the `const` cannot be `Drop` or mutable
+through a reference still apply. For instance, while the previous example was
+not legal, the following would be:
 
 ```rust
-const NOT_WINDOWS: i32 = if cfg!(windows) { 0 } else { 1 };
-let x: &'static i32 = &NOT_WINDOWS;
+const BOOL: i32 = {
+  let ret = if cfg!(windows) { 0 } else { 1 };
+  ret
+};
+
+let x: &'static i32 = &BOOL;
 ```
 
-However, an access to a `static` is only promotable within the initializer of
+An access to a `static` is only promotable within the initializer of
 another `static`.
 
 ### Panics

--- a/promotion.md
+++ b/promotion.md
@@ -85,9 +85,10 @@ contexts are treated as explicit.
 
 ## Promotability
 
-We have defined when it is desirable to promote expressions but have not yet
-defined which expressions can actually be promoted. We refer to such
-expressions as "promotable".
+We have described the circumstances where promotion is desirable, but what
+expressions are actually eligible for promotion? We refer to eligible
+expressions as "promotable" and describe the restrictions on such expressions
+below.
 
 ### Named locals
 

--- a/promotion.md
+++ b/promotion.md
@@ -20,7 +20,7 @@ That's why we have to be very conservative with what can and cannot be promoted.
 
 ## Rules
 
-### 1. Panics
+### Panics
 
 Promotion is not allowed to throw away side effects.  This includes panicking.
 Let us look at what happens when we promote `&(0_usize - 1)` in a debug build:
@@ -56,7 +56,7 @@ could not panic!) at run-time leads to a compile-time CTFE error.
 *Dynamic check.* The Miri engine already dynamically detects panics, but the
 main point of promoteds is ruling them out statically.
 
-### 2. Const safety
+### Const safety
 
 We have explained what happens when evaluating a promoted panics, but what about
 other kinds of failure -- what about hitting an unsupported operation or
@@ -105,7 +105,7 @@ For this reason, only `const fn` that were explicitly marked with the
 *Dynamic check.* The Miri engine already dynamically detects const safety
 violations, but the main point of promoteds is ruling them out statically.
 
-### 3. Drop
+### Drop
 
 Expressions returning "needs drop" types can never be promoted. If such an
 expression were promoted, the `Drop` impl would never get called on the value,

--- a/promotion.md
+++ b/promotion.md
@@ -37,7 +37,7 @@ non-`Copy` types to be initialized idiomatically, for example
 
 ### `#[rustc_args_required_const(...)]`
 
-Additionally, some platform intrinsics require certain operations to be
+Additionally, some platform intrinsics require certain parameters to be
 immediates (known at compile-time). We use the `#[rustc_args_required_const]`
 attribute, introduced in
 [rust-lang/rust#48018](https://github.com/rust-lang/rust/pull/48018), to
@@ -76,7 +76,7 @@ implicit context are a superset of the ones in an explicit context.
 
 We defined above that promotion guarantees that code in a non-const context
 will be executed at compile-time. However, lifetime extension and non-`Copy`
-array initialziation are useful features *inside* `const`s and `static`s as
+array initialization are useful features *inside* `const`s and `static`s as
 well. Strictly speaking, the transformation used to enable these features
 inside a const-context is not promotion; no `promoted`s are created in the MIR.
 However the same rules for promotability are used with one modification:

--- a/promotion.md
+++ b/promotion.md
@@ -79,9 +79,9 @@ Strictly speaking, lifetime extension in a const-context is not promotion; it
 does not create `promoted`s in the MIR.  However the same rules for
 promotability apply inside a const-context as outside.
 
-It's an open question whether lifetime extension within a `const` or `static`
-should be an implicit or explicit context. Currently it is treated as an
-implicit one.
+All contexts are treated as explicit ones when determining promotability within
+a `const` or `static` initializer because the user has requested that their
+code run at compile-time anyway.
 
 ## Promotability
 

--- a/promotion.md
+++ b/promotion.md
@@ -28,9 +28,10 @@ first context where promotion was done.
 
 ### Non-`Copy` array initialization
 
-Another promotion context was introduced in [RFC 2203][]. In this case, we try
-to promote the initializer in expressions like `[Vec::new(); 32]`, which allows
-non-`Copy` types to be used as array initializers.
+Another promotion context, the initializer of an array expression, was
+introduced in [RFC 2203][]. Here, promotion allows arrays of
+non-`Copy` types to be initialized idiomatically, for example
+`[Option::<Box<i32>>::None; 32]`.
 
 [RFC 2203]: https://github.com/rust-lang/rfcs/blob/master/text/2203-const-repeat-expr.md
 
@@ -71,18 +72,16 @@ implicit context are a superset of the ones in an explicit context.
 
 [warn-rfc]: https://github.com/rust-lang/rfcs/blob/master/text/1229-compile-time-asserts.md
 
-### Lifetime extension in `const` and `static`
+### Promotion contexts in `const` and `static`
 
 We defined above that promotion guarantees that code in a non-const context
-will be executed at compile-time. However, lifetime extension is useful
-*inside* `const`s and `static`s as well (unlike the other promotion contexts).
-Strictly speaking, lifetime extension in a const-context is not promotion; it
-does not create `promoted`s in the MIR.  However the same rules for
-promotability apply inside a const-context as outside.
-
-All contexts are treated as explicit ones when determining promotability within
-a `const` or `static` initializer because the user has requested that their
-code run at compile-time anyway.
+will be executed at compile-time. However, lifetime extension and non-`Copy`
+array initialziation are useful features *inside* `const`s and `static`s as
+well. Strictly speaking, the transformation used to enable these features
+inside a const-context is not promotion; no `promoted`s are created in the MIR.
+However the same rules for promotability are used with one modification:
+Because the user has already requested that this code run at compile time, all
+contexts are treated as explicit.
 
 ## Promotability
 


### PR DESCRIPTION
This adds an introduction to `promotion.md` that explains promotion in terms of "promotion contexts" (e.g. `&expr`, `[expr; 32]`) and "promotability" (the rules for which expressions can be promoted in a given context). This is a variation on the terminology described [in this comment](https://github.com/rust-rfcs/const-eval/pull/27#issuecomment-531953305), which I was using to reason about the code in `qualify_consts.rs` while working on dataflow-based const qualification.

I'm not asserting that this mental model is the correct one. In particular, you can see some inconsistencies in the section called "Lifetime extension in `const` and `static`". Hopefully it can serve as a starting point.

This also adds some requirements that were missing from the "Rules" section (now renamed to "Promotability"). These requirements are mostly structural ones (single assignment, no named variables), so maybe they should go in a different section?

cc @RalfJung @oli-obk 